### PR TITLE
Remove version specification from test_version

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,4 +8,5 @@ client = TestClient(app)
 def test_get_version() -> None:
     response = client.get("/v1/")
     assert response.status_code == 200
-    assert response.json() == {"version": "1.0.0"}
+    assert "version" in response.json()
+    assert isinstance(response.json()["version"], str)


### PR DESCRIPTION
Fixes #41

Remove the version check in the test_get_version function in tests/test_version.py.

* Modify the test_get_version function to check for the presence of the "version" key in the response JSON.
* Add a check to ensure the "version" value is a string.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/solufit/fastapi-template/issues/41?shareId=0039699b-e9b3-44cc-90d3-fa034e956824).