### PR TITLE
Fix mysql database name

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
     environment:
       MYSQL_ROOT_PASSWORD: mysql
-      MYSQL_DATABASE: mysql
+      MYSQL_DATABASE: solufit
       MYSQL_USER: mysql
       MYSQL_PASSWORD: mysql
       DEBUG: True
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: mysql
-      MYSQL_DATABASE: mysql
+      MYSQL_DATABASE: solufit
       MYSQL_USER: mysql
       MYSQL_PASSWORD: mysql
 

--- a/example.env
+++ b/example.env
@@ -1,6 +1,6 @@
 # Database Configuration
 MYSQL_ROOT_PASSWORD=mysql
-MYSQL_DATABASE=mysql
+MYSQL_DATABASE=solufit
 MYSQL_USER=mysql
 MYSQL_PASSWORD=mysql
 


### PR DESCRIPTION
Fixes #36

Change the MySQL database name to `solufit` in configuration files.

* **example.env**
  - Change `MYSQL_DATABASE` from `mysql` to `solufit`.

* **.devcontainer/docker-compose.yml**
  - Change `MYSQL_DATABASE` from `mysql` to `solufit` under `app` service.
  - Change `MYSQL_DATABASE` from `mysql` to `solufit` under `db` service.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/solufit/fastapi-template/issues/36?shareId=883d9893-1955-41c9-8618-6b3d5e836899).