### PR TITLE
Add pytest.ini to set test environment variables

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+env =
+    PYTEST=true
+    PYTEST_DB=sqlite:///:memory:


### PR DESCRIPTION
Fixes #38

Add pytest.ini to set test environment variables

* Add a new file `pytest.ini` to the root directory
* Set the environment variable `PYTEST=true` in the `pytest.ini` file
* Set the environment variable `PYTEST_DB=sqlite:///:memory:` in the `pytest.ini` file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/solufit/fastapi-template/issues/38?shareId=230632f4-97cc-4b67-8073-992cc5ba4ef7).